### PR TITLE
Removed bazel cache cleaning

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,7 +30,6 @@ $SCRIPT_DIR/set_tensorflow_bazelrc.sh $SRC_DIR/tensorflow
 
 #Clean up old bazel cache to avoid problems building TF
 bazel clean --expunge
-rm -rf ~/.cache/bazel
 bazel shutdown
 
 bazel --bazelrc=$SRC_DIR/tensorflow/tensorflow.bazelrc build \


### PR DESCRIPTION
On baremetal, this call fails with an error - `rm: cannot remove ‘/mnt/pai/home/npanpa23/.cache/bazel/_bazel_npanpa23/ff7f48f45686dc2b6e3e75dc528666f5/server’: Directory not empty`