### PR TITLE
Most probable fix for python invalid argument error

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ requirements:
     - bazel {{ bazel }}
     - pip
     - setuptools {{ setuptools }}
-    - python
+    - python {{ python }}
     - swig
 {% if build_type == 'cuda' %}
     - cudatoolkit-dev {{ cudatoolkit }}


### PR DESCRIPTION
This is the probable fix for that random problem of `python: invalid argument` error. 

Last time when I'd seen that error I had noticed that the error was coming from the `python` present at `$PREFIX/bin`. Also, when I tried running the same executable, it gave me the same error whereas `python` at `/opt/conda/bin` was working right. Since yesterday, I've not seen the error again after this change. Also, this error was observed mostly during TF builds, rest all the recipes have been working fine. But since the error was randomly reproducible, I'll wait for 2 more days to confirm that this change will fix that error. Even if it doesn't, I think this change should anyway be merged as it is necessary.

@jayfurmanek - If you have a container where the same error is being recreated, could you please try this fix?
