### PR TITLE
Updated TF to 2.3.1

### DIFF
--- a/meta_recipe/meta.yaml
+++ b/meta_recipe/meta.yaml
@@ -1,5 +1,5 @@
 # Recipe to build Tensorflow meta package
-{% set build_version = "2.3.0" %}
+{% set build_version = "2.3.1" %}
 {% set estimator_version = "2.3.0" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - 0302-Updated-pcre-to-8.44-for-a-security-fix.patch
 
 build:
-  number: 2
+  number: 3
 {% if build_type == 'cpu' %}
   string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
 {% else %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set tensorflow_select_version = '1.0' if build_type == 'cpu' else '2.0' %}
-{% set build_version = "2.3.0" %}
+{% set build_version = "2.3.1" %}
 
 # This is the recipe for the "cuda" variant of tensorflow-base
 package:
@@ -95,7 +95,6 @@ requirements:
     - wrapt {{ wrapt }}
     - wheel {{ wheel }}
     - six {{ six }}
-    - scipy {{ scipy }}
     - grpcio {{ grpcio }}
     - sqlite
   run:
@@ -124,7 +123,6 @@ requirements:
     - wrapt {{ wrapt }}
     - wheel {{ wheel }}
     - six {{ six }}
-    - scipy {{ scipy }}
     - grpcio {{ grpcio }}
     - sqlite
     - _tensorflow_select {{ tensorflow_select_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - 0302-Updated-pcre-to-8.44-for-a-security-fix.patch
 
 build:
-  number: 1
+  number: 2
 {% if build_type == 'cpu' %}
   string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
 {% else %}


### PR DESCRIPTION
Scipy is removed from TF's dependency list.