### PR TITLE
qualify CUDA_HOME usage

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,8 +53,10 @@ build:
     # - tensorboard = tensorboard.main:run_main
     - tf_upgrade_v2 = tensorflow.tools.compatibility.tf_upgrade_v2_main:main
     - estimator_ckpt_converter = tensorflow_estimator.python.estimator.tools.checkpoint_converter:main
+{% if build_type == 'cuda' %}
   script_env:
     - CUDA_HOME
+{% endif %}
 
 
 requirements:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

This allows the TF feedstock to build cpu only when CUDA_HOME is not defined.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
