### PR TITLE
typing_extensions only for py<38

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - 0303-Eigen-customized.patch                        #[ppc64le]
 
 build:
-  number: 2
+  number: 3
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,7 +101,7 @@ outputs:
         - wrapt {{ wrapt }}
         - wheel {{ wheel }}
         - six {{ six }}
-        - typing_extensions {{ typing_extensions }}
+        - typing_extensions {{ typing_extensions }}     #[py<38]
         - sqlite
       run:
         - python {{ python }}
@@ -130,7 +130,7 @@ outputs:
         - wrapt {{ wrapt }}
         - wheel {{ wheel }}
         - six {{ six }}
-        - typing_extensions {{ typing_extensions }}
+        - typing_extensions {{ typing_extensions }}     #[py<38]
         - sqlite
         - _tensorflow_select {{ tensorflow_select_version }}
 


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fix the typing_extensions dependency - its not needed for py38 and newer (its included in Python)

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
