### PR TITLE
C and C++ libs only in libtensorflow

### DIFF
--- a/recipe/build-libtensorflow.sh
+++ b/recipe/build-libtensorflow.sh
@@ -15,6 +15,19 @@ set -vex
 #
 # Include libtensorflow shared libraries and headers
 #
+
+TF_MAJOR_VERSION=${PKG_VERSION:0:1}
+echo "TF_MAJOR_VERSION: $TF_MAJOR_VERSION"
+
+# Move libtensorflow libs in from SRC_DIR cache
+mv ${SRC_DIR}/tensorflow_pkg/libtensorflow.so ${SP_DIR}/tensorflow/
+mv ${SRC_DIR}/tensorflow_pkg/libtensorflow_cc.so ${SP_DIR}/tensorflow/
+
+#Create version sym links
+ln -s ${SP_DIR}/tensorflow/libtensorflow_framework.so.[0-9] "${SP_DIR}/tensorflow/libtensorflow_framework.so"
+ln -s ${SP_DIR}/tensorflow/libtensorflow.so "${SP_DIR}/tensorflow/libtensorflow.so.${TF_MAJOR_VERSION}"
+ln -s ${SP_DIR}/tensorflow/libtensorflow_cc.so "${SP_DIR}/tensorflow/libtensorflow_cc.so.${TF_MAJOR_VERSION}"
+
 # Copy complete headers for libtensorflow C/C++ API
 mkdir -p "${SP_DIR}/tensorflow/include/tensorflow/cc"
 mkdir -p "${SP_DIR}/tensorflow/include/tensorflow/c"
@@ -36,10 +49,3 @@ else
     cp -R "${SRC_DIR}/tensorflow/include/tensorflow/cc/ops/"*.h "${SP_DIR}/tensorflow/include/tensorflow/cc/ops"
 fi
 
-TF_MAJOR_VERSION=${PKG_VERSION:0:1}
-echo "TF_MAJOR_VERSION: $TF_MAJOR_VERSION"
-
-#Create sym link for libtensorflow_framework
-ln -s ${SP_DIR}/tensorflow/libtensorflow_framework.so.[0-9] "${SP_DIR}/tensorflow/libtensorflow_framework.so"
-ln -s ${SP_DIR}/tensorflow/libtensorflow.so "${SP_DIR}/tensorflow/libtensorflow.so.${TF_MAJOR_VERSION}"
-ln -s ${SP_DIR}/tensorflow/libtensorflow_cc.so "${SP_DIR}/tensorflow/libtensorflow_cc.so.${TF_MAJOR_VERSION}"

--- a/recipe/build-pip-package.sh
+++ b/recipe/build-pip-package.sh
@@ -54,6 +54,11 @@ rm -f ${PREFIX}/bin/tensorboard
 echo "PREFIX: $PREFIX"
 echo "RECIPE_DIR: $RECIPE_DIR"
 
+# Cache libtensorflow libs in SRC_DIR so they can be picked up by
+# the libtensorflow output
+mv ${SP_DIR}/tensorflow/libtensorflow.so ${SRC_DIR}/tensorflow_pkg/
+mv ${SP_DIR}/tensorflow/libtensorflow_cc.so ${SRC_DIR}/tensorflow_pkg/
+
 # Install the activate / deactivate scripts that set environment variables
 mkdir -p "${PREFIX}"/etc/conda/activate.d
 mkdir -p "${PREFIX}"/etc/conda/deactivate.d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - 0303-Eigen-customized.patch                        #[ppc64le]
 
 build:
-  number: 4
+  number: 5
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

This changes the build scripts slightly so that `libtensorflow.so` (C API) and `libtensorflow_cc.so` are only present in the `libtensorflow` package. The `libtensorflow_framework.so` file will remain in the `tensorflow-base` package.

This matches the official TensorFlow whl files and helps reduce the size of the base package.
Any other recipes that need these libraries will need to pull in the libtensorflow package now.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
