### PR TITLE
Adjust sqlite runtime dep

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -131,7 +131,7 @@ outputs:
         - wheel {{ wheel }}
         - six {{ six }}
         - typing_extensions {{ typing_extensions }}     #[py<38]
-        - sqlite
+        - {{ pin_compatible('sqlite', lower_bound='3.33.0', upper_bound='4.0a0') }}
         - _tensorflow_select {{ tensorflow_select_version }}
 
   - name: libtensorflow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - 0305-Updated-protobuf-to-3.11.2.patch              #[protobuf == "3.11.2"]
 
 build:
-  number: 6
+  number: 7
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

There is now sqlite 3.35 in the defaults repo. This is good but we dont want run_exports pinning to that version, so let's specify it in the meta.yaml.

This results in:

```
dependencies: 
  - _tensorflow_select 2.0.*
  - absl-py 0.10.*
  - astunparse 1.6.*
  - cudatoolkit 10.2.*
  - cudnn 7.6.5.*
  - gast 0.3.3.*
  - google-pasta 0.2.*
  - h5py 2.10.0.*
  - keras-preprocessing 1.1.*
  - libgcc-ng >=7.2.0
  - libstdcxx-ng >=7.2.0
  - nccl 2.7.*
  - numpy 1.19.*
  - opt_einsum 3.1.0.*
  - pillow 8.1.*
  - protobuf 3.11.2.*
  - python >=3.7,<3.8.0a0
  - python-flatbuffers 1.12.*
  - six 1.15.0.*
  - sqlite >=3.33.0,<4.0a0
  - tensorrt 7.0.*
  - termcolor 1.1.0.*
  - typing_extensions 3.7.4.*
  - wheel 0.35.*
  - wrapt 1.12.*
  - zlib >=1.2.11,<1.3.0a0
```


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
