### PR TITLE
Copy libs cache

### DIFF
--- a/recipe/build-pip-package.sh
+++ b/recipe/build-pip-package.sh
@@ -36,8 +36,6 @@ $SCRIPT_DIR/set_tensorflow_bazelrc.sh $SRC_DIR/tensorflow
 #Clean up old bazel cache to avoid problems building TF
 bazel clean --expunge
 bazel shutdown
-echo "CAche dir: $cached_dir"
-#exit 1
 
 bazel --bazelrc=$SRC_DIR/tensorflow/tensorflow.bazelrc build \
     --config=opt \
@@ -63,9 +61,12 @@ echo "RECIPE_DIR: $RECIPE_DIR"
 
 # Cache libtensorflow libs in SRC_DIR so they can be picked up by
 # the libtensorflow output
+TF_MAJOR_VERSION=${PKG_VERSION:0:1}
+echo "TF_MAJOR_VERSION: $TF_MAJOR_VERSION"
+
 mv ${SP_DIR}/tensorflow/libtensorflow.so ${SRC_DIR}/tensorflow_pkg/
 mv ${SP_DIR}/tensorflow/libtensorflow_cc.so ${SRC_DIR}/tensorflow_pkg/
-mv ${SP_DIR}/tensorflow/libtensorflow_framework.so.2 ${SRC_DIR}/tensorflow_pkg/
+mv ${SP_DIR}/tensorflow/libtensorflow_framework.so.${TF_MAJOR_VERSION} ${SRC_DIR}/tensorflow_pkg/
 
 #Cache the libs and headers needed by libtensorflow
 

--- a/recipe/build-pip-package.sh
+++ b/recipe/build-pip-package.sh
@@ -36,6 +36,8 @@ $SCRIPT_DIR/set_tensorflow_bazelrc.sh $SRC_DIR/tensorflow
 #Clean up old bazel cache to avoid problems building TF
 bazel clean --expunge
 bazel shutdown
+echo "CAche dir: $cached_dir"
+#exit 1
 
 bazel --bazelrc=$SRC_DIR/tensorflow/tensorflow.bazelrc build \
     --config=opt \
@@ -63,6 +65,20 @@ echo "RECIPE_DIR: $RECIPE_DIR"
 # the libtensorflow output
 mv ${SP_DIR}/tensorflow/libtensorflow.so ${SRC_DIR}/tensorflow_pkg/
 mv ${SP_DIR}/tensorflow/libtensorflow_cc.so ${SRC_DIR}/tensorflow_pkg/
+mv ${SP_DIR}/tensorflow/libtensorflow_framework.so.2 ${SRC_DIR}/tensorflow_pkg/
+
+#Cache the libs and headers needed by libtensorflow
+
+CACHE_DIR="/tmp/tf-libs"
+if [ -d $CACHE_DIR ]; then
+    rm -rf $CACHE_DIR
+fi
+
+mkdir -p $CACHE_DIR/lib
+mkdir -p $CACHE_DIR/include
+
+cp "${SRC_DIR}/tensorflow_pkg/"*.so* $CACHE_DIR/lib
+cp "${SRC_DIR}/tensorflow/include/tensorflow/cc/ops/"*.h $CACHE_DIR/include
 
 # Install the activate / deactivate scripts that set environment variables
 mkdir -p "${PREFIX}"/etc/conda/activate.d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - 0305-Updated-protobuf-to-3.11.2.patch              #[protobuf == "3.11.2"]
 
 build:
-  number: 9
+  number: 10
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - 0305-Updated-protobuf-to-3.11.2.patch              #[protobuf == "3.11.2"]
 
 build:
-  number: 10
+  number: 11
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,7 +112,6 @@ outputs:
         - tensorrt {{ tensorrt }}     #[py<38]
         {% endif %}
         # Included for keras team keras
-        - pillow {{ pillow }}
         # List from TensorFlow setup.py
         - absl-py {{ absl_py }}
         - astunparse {{ astunparse }}


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Fixes following two issues -
1. If tensorflow-base is already built but not libtensorflow package, the subsequent build of libtensorflow used to fail because it uses the artifacts generated by tensorflow-base build and which are cached in conda-bld dir..And since cond-bld is already cleared, libtensorflow would not find the needed stuff and hence it used to fail and the user used to be forced to rebuild tensorflow-base.
2. libtensorflow package used to contain the dangling link of libtensorflow_framework.so in the package as the original lib was missing.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
