### PR TITLE
Fixed issue with libtensorflow package having dangling link of libtensorflow_framework.so

### DIFF
--- a/recipe/build-libtensorflow.sh
+++ b/recipe/build-libtensorflow.sh
@@ -27,6 +27,7 @@ echo "TF_MAJOR_VERSION: $TF_MAJOR_VERSION"
 # Move libtensorflow libs in from SRC_DIR cache
 mv ${SRC_DIR}/tensorflow_pkg/libtensorflow.so ${SP_DIR}/tensorflow/
 mv ${SRC_DIR}/tensorflow_pkg/libtensorflow_cc.so ${SP_DIR}/tensorflow/
+mv ${SRC_DIR}/tensorflow_pkg/libtensorflow_framework.so.[0-9] ${SP_DIR}/tensorflow/
 
 #Create version sym links
 ln -s ${SP_DIR}/tensorflow/libtensorflow_framework.so.[0-9] "${SP_DIR}/tensorflow/libtensorflow_framework.so"

--- a/recipe/build-pip-package.sh
+++ b/recipe/build-pip-package.sh
@@ -61,8 +61,12 @@ echo "RECIPE_DIR: $RECIPE_DIR"
 
 # Cache libtensorflow libs in SRC_DIR so they can be picked up by
 # the libtensorflow output
+TF_MAJOR_VERSION=${PKG_VERSION:0:1}
+echo "TF_MAJOR_VERSION: $TF_MAJOR_VERSION"
+
 mv ${SP_DIR}/tensorflow/libtensorflow.so ${SRC_DIR}/tensorflow_pkg/
 mv ${SP_DIR}/tensorflow/libtensorflow_cc.so ${SRC_DIR}/tensorflow_pkg/
+mv ${SP_DIR}/tensorflow/libtensorflow_framework.so.${TF_MAJOR_VERSION} ${SRC_DIR}/tensorflow_pkg/
 
 # Install the activate / deactivate scripts that set environment variables
 mkdir -p "${PREFIX}"/etc/conda/activate.d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - 0305-Updated-protobuf-to-3.11.2.patch              #[protobuf == "3.11.2"]
 
 build:
-  number: 10
+  number: 11
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main


### PR DESCRIPTION
Fixes issue - libtensorflow package had a dangling link to libtensorflow_frameworks.so.

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Fixes following issue -

1. libtensorflow package used to contain the dangling link of libtensorflow_framework.so in the package as the original lib was missing.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
