### PR TITLE
The select pkg build string doesn't need cuda version

### DIFF
--- a/select_recipe/meta.yaml
+++ b/select_recipe/meta.yaml
@@ -6,11 +6,7 @@ package:
 
 build:
   number: 1
-{% if build_type == 'cpu' %}
   string: {{ build_type }}_{{ PKG_BUILDNUM }}
-{% else %}
-  string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
-{% endif %}
 
 about:
   summary : Package used to select the specific Tensorflow build variant

--- a/select_recipe/meta.yaml
+++ b/select_recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ tensorflow_select_version }}
 
 build:
-  number: 1
+  number: 2
   string: {{ build_type }}_{{ PKG_BUILDNUM }}
 
 about:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

The build string for the select package only needs the build_type.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
