### PR TITLE
Putting libtensorflow_framework.so back into tensorflow-base

### DIFF
--- a/recipe/build-libtensorflow.sh
+++ b/recipe/build-libtensorflow.sh
@@ -27,10 +27,8 @@ echo "TF_MAJOR_VERSION: $TF_MAJOR_VERSION"
 # Move libtensorflow libs in from SRC_DIR cache
 mv ${SRC_DIR}/tensorflow_pkg/libtensorflow.so ${SP_DIR}/tensorflow/
 mv ${SRC_DIR}/tensorflow_pkg/libtensorflow_cc.so ${SP_DIR}/tensorflow/
-mv ${SRC_DIR}/tensorflow_pkg/libtensorflow_framework.so.[0-9] ${SP_DIR}/tensorflow/
 
 #Create version sym links
-ln -s ${SP_DIR}/tensorflow/libtensorflow_framework.so.[0-9] "${SP_DIR}/tensorflow/libtensorflow_framework.so"
 ln -s ${SP_DIR}/tensorflow/libtensorflow.so "${SP_DIR}/tensorflow/libtensorflow.so.${TF_MAJOR_VERSION}"
 ln -s ${SP_DIR}/tensorflow/libtensorflow_cc.so "${SP_DIR}/tensorflow/libtensorflow_cc.so.${TF_MAJOR_VERSION}"
 

--- a/recipe/build-pip-package.sh
+++ b/recipe/build-pip-package.sh
@@ -68,7 +68,7 @@ echo "TF_MAJOR_VERSION: $TF_MAJOR_VERSION"
 
 mv ${SP_DIR}/tensorflow/libtensorflow.so ${SRC_DIR}/tensorflow_pkg/
 mv ${SP_DIR}/tensorflow/libtensorflow_cc.so ${SRC_DIR}/tensorflow_pkg/
-mv ${SP_DIR}/tensorflow/libtensorflow_framework.so.${TF_MAJOR_VERSION} ${SRC_DIR}/tensorflow_pkg/
+ln -s ${SP_DIR}/tensorflow/libtensorflow_framework.so.${TF_MAJOR_VERSION} ${SP_DIR}/tensorflow/libtensorflow_framework.so
 
 # Install the activate / deactivate scripts that set environment variables
 mkdir -p "${PREFIX}"/etc/conda/activate.d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - 0308-Upstream-patch-to-disable-absl-cord.patch     #[cudatoolkit == "10.2"]
 
 build:
-  number: 1 
+  number: 2
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Putting libtensorflow_framework.so back into Tensorflow-base as it is needed for tensorflow python wrapper. 
This should also fix CI builds of TF Text and TF Estimator.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
