### PR TITLE
disable ppc64le custom gemm_pack_rhs to use the convolution specializ…

### DIFF
--- a/config/conda_build_config.yaml
+++ b/config/conda_build_config.yaml
@@ -1,7 +1,9 @@
 c_compiler_version:
-  - 7.3.0                     
+  - 7.3.0          # [x86_64]               
+  - 8.2.0          # [ppc64le]
 cxx_compiler_version:
-  - 7.3.0                     
+  - 7.3.0          # [x86_64]
+  - 8.2.0          # [ppc64le]
 # One can change the value for below field on x86_64 if MKL is to be turned on.
 use_mkl:
   - "false"

--- a/recipe/0309-disable-ppc64le-custom-gemm_pack_rhs-to-use-the-convolution-specialization
+++ b/recipe/0309-disable-ppc64le-custom-gemm_pack_rhs-to-use-the-convolution-specialization
@@ -1,0 +1,159 @@
+warning: refname 'v2.5.0' is ambiguous.
+diff --git a/tensorflow/core/kernels/BUILD b/tensorflow/core/kernels/BUILD
+index c65695c3cab..e06a779424b 100644
+--- a/tensorflow/core/kernels/BUILD
++++ b/tensorflow/core/kernels/BUILD
+@@ -939,6 +939,9 @@ cc_library(
+         "eigen_convolution_helpers.h",
+     ],
+     compatible_with = get_compatible_with_portable(),
++    defines = [
++        "EIGEN_ALTIVEC_USE_CUSTOM_PACK=0",
++    ],
+ )
+ 
+ # OpKernel libraries ----------------------------------------------------------
+@@ -3966,8 +3969,7 @@ cc_library(
+     ],
+ )
+ 
+-NN_DEPS = [
+-    ":conv_2d",
++NN_DEPS = if_cuda_or_rocm([":conv_2d"]) + [
+     ":eigen_contraction_kernel",
+     ":ops_util",
+     "//tensorflow/core:framework",
+diff --git a/tensorflow/core/kernels/eigen_backward_cuboid_convolutions.h b/tensorflow/core/kernels/eigen_backward_cuboid_convolutions.h
+index 9a2d431b0d8..958f1149dc9 100644
+--- a/tensorflow/core/kernels/eigen_backward_cuboid_convolutions.h
++++ b/tensorflow/core/kernels/eigen_backward_cuboid_convolutions.h
+@@ -17,6 +17,7 @@ limitations under the License.
+ #define TENSORFLOW_CORE_KERNELS_EIGEN_BACKWARD_CUBOID_CONVOLUTIONS_H_
+ 
+ #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
++#include "tensorflow/core/kernels/eigen_cuboid_convolution.h"
+ 
+ namespace Eigen {
+ 
+diff --git a/tensorflow/core/kernels/eigen_backward_spatial_convolutions.h b/tensorflow/core/kernels/eigen_backward_spatial_convolutions.h
+index 8c4c86acd66..881efed4bc2 100644
+--- a/tensorflow/core/kernels/eigen_backward_spatial_convolutions.h
++++ b/tensorflow/core/kernels/eigen_backward_spatial_convolutions.h
+@@ -17,6 +17,7 @@ limitations under the License.
+ #define TENSORFLOW_CORE_KERNELS_EIGEN_BACKWARD_SPATIAL_CONVOLUTIONS_H_
+ 
+ #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
++#include "tensorflow/core/kernels/eigen_spatial_convolutions.h"
+ 
+ namespace Eigen {
+ 
+diff --git a/tensorflow/core/kernels/eigen_cuboid_convolution.h b/tensorflow/core/kernels/eigen_cuboid_convolution.h
+index d12db1b92a0..bf0cdd59e4f 100644
+--- a/tensorflow/core/kernels/eigen_cuboid_convolution.h
++++ b/tensorflow/core/kernels/eigen_cuboid_convolution.h
+@@ -24,17 +24,11 @@ limitations under the License.
+ 
+ #include "tensorflow/core/kernels/eigen_convolution_helpers.h"
+ 
+-#if defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)
+-#define TF_USE_CUSTOM_EIGEN_PACK 0
+-#else
+-#define TF_USE_CUSTOM_EIGEN_PACK 1
+-#endif
+-
+ namespace Eigen {
+ 
+ namespace internal {
+ 
+-#if TF_USE_CUSTOM_EIGEN_PACK
++#if !EIGEN_ALTIVEC_USE_CUSTOM_PACK
+ // WARNING: Most of the code here implicitly assumes that the matrix is in
+ // ColMajor layout. This is guaranteed by the tensor contraction (see
+ // TensorContraction.h).
+@@ -1364,6 +1358,15 @@ struct gemm_pack_rhs<
+     }
+ 
+     // Copy the remaining columns one at a time (nr==1).
++#if defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)
++    // remaining columns are handled different for PPC
++    for (Index k = 0; k < depth; k++) {
++      for (Index j2 = packet_cols4; j2 < cols; ++j2) {
++        *block = rhs(k, j2);
++        block += 1;
++      }
++    }
++#else
+     for (Index j2 = packet_cols4; j2 < cols; ++j2) {
+       const SubMapper dm0 = rhs.getLinearMapper(0, j2);
+       for (Index k = 0; k < depth; k++) {
+@@ -1371,6 +1374,7 @@ struct gemm_pack_rhs<
+         block += 1;
+       }
+     }
++#endif
+   }
+ };
+ 
+diff --git a/tensorflow/core/kernels/eigen_spatial_convolutions-inl.h b/tensorflow/core/kernels/eigen_spatial_convolutions-inl.h
+index 1fb30f6dec3..ef5dce95b8f 100644
+--- a/tensorflow/core/kernels/eigen_spatial_convolutions-inl.h
++++ b/tensorflow/core/kernels/eigen_spatial_convolutions-inl.h
+@@ -18,18 +18,12 @@ limitations under the License.
+ 
+ #include "tensorflow/core/kernels/eigen_convolution_helpers.h"
+ 
+-#if defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)
+-#define TF_USE_CUSTOM_EIGEN_PACK 0
+-#else
+-#define TF_USE_CUSTOM_EIGEN_PACK 1
+-#endif
+-
+ // Note this header is used in both TF and TFLite.
+ namespace Eigen {
+ 
+ namespace internal {
+ 
+-#if TF_USE_CUSTOM_EIGEN_PACK
++#if !EIGEN_ALTIVEC_USE_CUSTOM_PACK
+ // WARNING: Most of the code here implicitly assumes that the matrix is in
+ // ColMajor layout. This is guaranteed by the tensor contraction (see
+ // TensorContraction.h).
+@@ -1239,6 +1233,15 @@ struct gemm_pack_rhs<
+     }
+ 
+     // copy the remaining columns one at a time (nr==1)
++#if defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)
++    // remaining columns are handled different for PPC
++    for (Index k = 0; k < depth; k++) {
++      for (Index j2 = packet_cols4; j2 < cols; ++j2) {
++        *block = rhs(k, j2);
++        block += 1;
++      }
++    }
++#else
+     for (Index j2 = packet_cols4; j2 < cols; ++j2) {
+       const SubMapper dm0 = rhs.getLinearMapper(0, j2);
+       for (Index k = 0; k < depth; k++) {
+@@ -1246,6 +1249,7 @@ struct gemm_pack_rhs<
+         block += 1;
+       }
+     }
++#endif
+   }
+ };
+ 
+diff --git a/third_party/eigen3/workspace.bzl b/third_party/eigen3/workspace.bzl
+index 233231f5636..96371dda195 100644
+--- a/third_party/eigen3/workspace.bzl
++++ b/third_party/eigen3/workspace.bzl
+@@ -6,8 +6,8 @@ def repo():
+     """Imports Eigen."""
+ 
+     # Attention: tools parse and update these lines.
+-    EIGEN_COMMIT = "f612df273689a19d25b45ca4f8269463207c4fee"
+-    EIGEN_SHA256 = "e3fe5cac59763b7419af2de39840b5342d77624ddf8b181fb9f9f532615ec518"
++    EIGEN_COMMIT = "7b35638ddb99a0298c5d3450de506a8e8e0203d3"
++    EIGEN_SHA256 = "2f25d7d0279c57ce7c533bc71ba78af9c24a0a0aac4102bfeb28c2b5737499d1"
+ 
+     tf_http_archive(
+         name = "eigen_archive",

--- a/recipe/0309-disable-ppc64le-custom-gemm_pack_rhs-to-use-the-convolution-specialization
+++ b/recipe/0309-disable-ppc64le-custom-gemm_pack_rhs-to-use-the-convolution-specialization
@@ -1,4 +1,31 @@
-warning: refname 'v2.5.0' is ambiguous.
+From b12b446d9fdf10e22356f0d2212570e1084fd466 Mon Sep 17 00:00:00 2001
+From: "Maxiwell S. Garcia" <maxiwell@linux.ibm.com>
+Date: Wed, 7 Jul 2021 13:08:02 -0700
+Subject: [PATCH] Disable ppc64le custom gemm_pack_rhs to use the
+convolution specialization
+
+BUILD: Only include conv_2d rule on NN_DEPS in case of cuda and rocm
+
+Disable ppc64le custom gemm_pack_rhs to use the convolution specialization
+
+Eigen ppc64le has a gemm_pack_rhs specialization for AltiVec architecture.
+TF Convolution also specializes this packing routine, improving the Tensor
+code and avoiding a lot of index computation. Based on eigen_benchmark_cpu_test,
+we found a good scenario for ppc64le, where gemm_pack_rhs from TF headers
+together with VSX/MMA from ppc64le speeds up the performance of convolution.
+
+This patch fixes the column computation for convolution in case of ppc64le
+and disables the Eigen ppc64le gemm_pack_rhs using the define
+EIGEN_ALTIVEC_USE_CUSTOM_PACK=0
+---
+ tensorflow/core/kernels/BUILD                  |  6 ++++--
+ .../eigen_backward_cuboid_convolutions.h       |  1 +
+ .../eigen_backward_spatial_convolutions.h      |  1 +
+ .../core/kernels/eigen_cuboid_convolution.h    | 18 +++++++++++-------
+ .../kernels/eigen_spatial_convolutions-inl.h   | 18 +++++++++++-------
+ third_party/eigen3/workspace.bzl               |  4 ++--
+ 6 files changed, 30 insertions(+), 18 deletions(-)
+
 diff --git a/tensorflow/core/kernels/BUILD b/tensorflow/core/kernels/BUILD
 index c65695c3cab..e06a779424b 100644
 --- a/tensorflow/core/kernels/BUILD
@@ -157,3 +184,6 @@ index 233231f5636..96371dda195 100644
  
      tf_http_archive(
          name = "eigen_archive",
+-- 
+2.23.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,10 +36,10 @@ source:
     - 0306-Fix-absl-linker-error.patch
     - 0307-Fix-for-eigen-TensorReduction.patch           #[x86_64]
     - 0308-Upstream-patch-to-disable-absl-cord.patch     #[cudatoolkit == "10.2"]
-    - 0309-disable-ppc64le-custom-gemm_pack_rhs-to-use-the-convolution-specialization
+    - 0309-disable-ppc64le-custom-gemm_pack_rhs-to-use-the-convolution-specialization # [ppc64le]
 
 build:
-  number: 4
+  number: 5
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ source:
     - 0306-Fix-absl-linker-error.patch
     - 0307-Fix-for-eigen-TensorReduction.patch           #[x86_64]
     - 0308-Upstream-patch-to-disable-absl-cord.patch     #[cudatoolkit == "10.2"]
+    - 0309-disable-ppc64le-custom-gemm_pack_rhs-to-use-the-convolution-specialization
 
 build:
   number: 4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ source:
     - 0309-disable-ppc64le-custom-gemm_pack_rhs-to-use-the-convolution-specialization # [ppc64le]
 
 build:
-  number: 5
+  number: 6
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main


### PR DESCRIPTION
…ation

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Eigen ppc64le has a gemm_pack_rhs specialization for AltiVec architecture. TF Convolution also specializes this packing routine, improving the Tensor code and avoiding a lot of index computation. Based on eigen_benchmark_cpu_test, we found a good scenario for ppc64le, where gemm_pack_rhs from TF headers together with VSX/MMA from ppc64le speeds up the performance of convolution.

This patch fixes the column computation for convolution in case of ppc64le and disables the Eigen ppc64le gemm_pack_rhs using the define EIGEN_ALTIVEC_USE_CUSTOM_PACK=0.

This patch also moves up the commit for Eigen as a newer one is needed for this to work.

Commited upstream post 2.6 in:  https://github.com/tensorflow/tensorflow/pull/50677

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
