### PR TITLE
Reset build number to 1 with 2.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ source:
     - 0309-disable-ppc64le-custom-gemm_pack_rhs-to-use-the-convolution-specialization.patch # [ppc64le]
 
 build:
-  number: 3
+  number: 1
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Reset build number to 1. With 2.6.0 version update, the build number should be reset to 1. It was set to 1 in my earlier PR for TF 2.6.0 refresh https://github.com/npanpaliya/tensorflow-feedstock/blob/260-update/recipe/meta.yaml#L42. But don't know it is still 3 in the main branch even after merging my PR (may be due to conflicts).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
