### PR TITLE
Enable s390x support for TensorFlow

### DIFF
--- a/buildscripts/set_tensorflow_bazelrc.sh
+++ b/buildscripts/set_tensorflow_bazelrc.sh
@@ -31,7 +31,7 @@ if [ -z "${cpu_opt_tune}"]; then
      CPU_ARCH_OPTION='';
      CPU_ARCH_HOST_OPTION='';
 else
-     if [[ "${ARCH}" == 'x86_64' ]]; then
+     if [[ "${ARCH}" == 'x86_64' || "${ARCH}" == 's390x' ]]; then
           CPU_ARCH_FRAG="-march=${cpu_opt_arch}"
      fi
      if [[ "${ARCH}" == 'ppc64le' ]]; then
@@ -91,5 +91,14 @@ if [[ $use_mkl == "true" && "${ARCH}" == 'x86_64' ]]; then
 echo "Enabled MKL"
 cat >> $BAZEL_RC_DIR/tensorflow.bazelrc << EOF
 build --config=mkl
+EOF
+fi
+
+if [[ "${ARCH}" == 's390x' ]]; then
+echo "Building with more compiler flag for ${ARCH}"
+# extra compiler flag added for further optimization
+cat >> $BAZEL_RC_DIR/tensorflow.bazelrc << EOF
+build:opt --copt=-O3
+build:opt --copt=-funroll-loops
 EOF
 fi

--- a/meta_recipe/meta.yaml
+++ b/meta_recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - tensorboard          =={{ tensorboard }}
     - tensorflow-estimator =={{ estimator_version }}
     - keras                =={{ keras }}
-    - tensorflow-io-gcs-filesystem {{ tensorflow_io_gcs_filesystem }}
+    - tensorflow-io-gcs-filesystem {{ tensorflow_io_gcs_filesystem }} [not s390x]
     - python                 {{ python }}
     - cudatoolkit            {{ cudatoolkit }} #[build_type == 'cuda']
 

--- a/recipe/0311-Build-llvm-for-s390x-target.patch
+++ b/recipe/0311-Build-llvm-for-s390x-target.patch
@@ -1,0 +1,29 @@
+diff --git a/third_party/llvm/fix_s390x.patch b/third_party/llvm/fix_s390x.patch
+new file mode 100644
+index 00000000000..eb448168861
+--- /dev/null
++++ b/third_party/llvm/fix_s390x.patch
+@@ -0,0 +1,12 @@
++diff --git a/utils/bazel/llvm-project-overlay/llvm/config.bzl b/utils/bazel/llvm-project-overlay/llvm/config.bzl
++index 2046b2645362..6bb22f389576 100644
++--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
+++++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
++@@ -86,6 +86,7 @@ llvm_config_defines = os_defines + select({
++     "@bazel_tools//src/conditions:darwin_arm64": native_arch_defines("AArch64", "arm64-apple-darwin"),
++     "@bazel_tools//src/conditions:darwin_x86_64": native_arch_defines("X86", "x86_64-unknown-darwin"),
++     "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
+++    "@bazel_tools//src/conditions:linux_s390x": native_arch_defines("SystemZ", "s390x-unknown-linux-gnu"),
++     "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu"),
++ }) + [
++     # These shouldn't be needed by the C++11 standard, but are for some
+diff --git a/third_party/llvm/workspace.bzl b/third_party/llvm/workspace.bzl
+index 7bc6b54a20f..a985cdf759a 100644
+--- a/third_party/llvm/workspace.bzl
++++ b/third_party/llvm/workspace.bzl
+@@ -16,5 +16,5 @@ def repo(name):
+             "https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
+         ],
+         build_file = "//third_party/llvm:BUILD.bazel",
+-        patch_file = "//third_party/llvm:macos_build_fix.patch",
++        patch_file = "//third_party/llvm:fix_s390x.patch",
+     )

--- a/recipe/0312-EIGEN-grpc-fix-s390x-target.patch
+++ b/recipe/0312-EIGEN-grpc-fix-s390x-target.patch
@@ -1,0 +1,46 @@
+diff --git a/tensorflow/distribute/experimental/rpc/kernels/BUILD b/tensorflow/distribute/experimental/rpc/kernels/BUILD
+index 9f92501443b..05c81fb5703 100644
+--- a/tensorflow/distribute/experimental/rpc/kernels/BUILD
++++ b/tensorflow/distribute/experimental/rpc/kernels/BUILD
+@@ -17,7 +17,7 @@ cc_library(
+     deps = [
+         "//tensorflow/distribute/experimental/rpc/proto:tf_rpc_service_proto_cc",
+         "//tensorflow/stream_executor/platform",
+-        "@com_github_grpc_grpc//:grpc++",
++        "//tensorflow:grpc++",
+     ],
+     alwayslink = 1,
+ )
+@@ -26,7 +26,7 @@ cc_library(
+     name = "grpc_credentials",
+     hdrs = ["grpc_credentials.h"],
+     deps = [
+-        "@com_github_grpc_grpc//:grpc++",
++        "//tensorflow:grpc++",
+     ] + grpc_credentials_dependency(),
+ )
+ 
+@@ -47,7 +47,7 @@ tf_kernel_library(
+         "//tensorflow/core/distributed_runtime/rpc:grpc_util",
+         "//tensorflow/distribute/experimental/rpc/proto:tf_rpc_service_proto_cc",
+         "//tensorflow/stream_executor/platform",
+-        "@com_github_grpc_grpc//:grpc++",
++        "//tensorflow:grpc++",
+         "@com_google_absl//absl/strings",
+         "@com_google_absl//absl/strings:str_format",
+     ],
+diff --git a/third_party/eigen3/workspace.bzl b/third_party/eigen3/workspace.bzl
+index 21799365434..116f5976d08 100644
+--- a/third_party/eigen3/workspace.bzl
++++ b/third_party/eigen3/workspace.bzl
+@@ -7,8 +7,8 @@ def repo():
+ 
+     # Attention: tools parse and update these lines.
+     # LINT.IfChange
+-    EIGEN_COMMIT = "7792b1e909a98703181aecb8810b4b654004c25d"
+-    EIGEN_SHA256 = "517a02cd24362fd9284ce61e8baeeabb4fee181941752da47eb4c07a52d38d4d"
++    EIGEN_COMMIT = "40bbe8a4d0eb3ec2bfd472fa30cac19e6e743b46"
++    EIGEN_SHA256 = "dc439a8b420d75c0664e55d334bf7228103db53d7a176030ff03d224a9429fa6"
+     # LINT.ThenChange(//tensorflow/lite/tools/cmake/modules/eigen.cmake)
+ 
+     tf_http_archive(

--- a/recipe/0313-hwloc-fix-s390x.patch
+++ b/recipe/0313-hwloc-fix-s390x.patch
@@ -1,0 +1,15 @@
+diff --git a/third_party/hwloc/BUILD.bazel b/third_party/hwloc/BUILD.bazel
+index 46149dd497f..c95616e1780 100644
+--- a/third_party/hwloc/BUILD.bazel
++++ b/third_party/hwloc/BUILD.bazel
+@@ -270,6 +270,10 @@ cc_library(
+             "hwloc/topology-linux.c",
+             "include/hwloc/linux.h",
+         ],
++        "@org_tensorflow//tensorflow:linux_s390x": [
++            "hwloc/topology-linux.c",
++            "include/hwloc/linux.h",
++        ],
+         "@org_tensorflow//tensorflow:freebsd": [
+             "hwloc/topology-freebsd.c",
+             "hwloc/topology-x86.c",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,9 @@ source:
     - 0307-Fix-for-eigen-TensorReduction.patch           #[x86_64]
     - 0309-Build-llvm-for-ppc64le-target.patch           #[ppc64le]
     - 0310-Updated-Dist-info-for-tf-estimator-tensorboard-and-k.patch
+    - 0311-Build-llvm-for-s390x-target.patch             #[s390x]
+    - 0312-EIGEN-grpc-fix-s390x-target.patch             #[s390x]
+    - 0313-hwloc-fix-s390x.patch                         #[s390x]
 
 build:
   number: 3
@@ -103,7 +106,8 @@ outputs:
         - wheel {{ wheel }}
         - six {{ six }}
         - typing_extensions {{ typing_extensions }}     #[py<38]
-        - sqlite 3.33.0
+        - sqlite 3.33.0                                 #[not s390x]
+        - sqlite {{ sqlite }}                           #[s390x]
         - grpcio {{ grpcio }}
       run:
         - python {{ python }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ source:
     - 0313-hwloc-fix-s390x.patch                         #[s390x]
 
 build:
-  number: 3
+  number: 4
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main


### PR DESCRIPTION


## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
Fixes # (issue).
- Includes fix for `boringSSL` build issue for s390x
  `https://github.com/tensorflow/tensorflow/issues/51770`
   and `https://github.com/tensorflow/tensorflow/pull/54352`
- Includes `ZVector` support patch (commit) for eigen.
- llvm fix added for s390x target.  
  ref: `https://github.com/open-ce/tensorflow-feedstock/blob/main/recipe/0309-Build-llvm-for-ppc64le-target.patch`
- `NUMA` enablement added for s390x.(`TODO`: further testing required)

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
