### PR TITLE
Backport - tensor_content swap fix for s390x

### DIFF
--- a/recipe/0314-Fix-Tensor-content-swap-s390x.patch
+++ b/recipe/0314-Fix-Tensor-content-swap-s390x.patch
@@ -1,0 +1,327 @@
+diff --git a/tensorflow/cc/saved_model/bundle_v2.cc b/tensorflow/cc/saved_model/bundle_v2.cc
+index b25814c653c..5eaa6705e31 100644
+--- a/tensorflow/cc/saved_model/bundle_v2.cc
++++ b/tensorflow/cc/saved_model/bundle_v2.cc
+@@ -28,6 +28,7 @@ limitations under the License.
+ #include "tensorflow/core/platform/strcat.h"
+ #include "tensorflow/core/protobuf/saved_model.pb.h"
+ #include "tensorflow/core/protobuf/trackable_object_graph.pb.h"
++#include "tensorflow/core/util/tensor_bundle/byte_swap.h"
+ 
+ namespace tensorflow {
+ namespace {
+@@ -113,6 +114,11 @@ Status SavedModelV2Bundle::Load(const std::string& export_dir,
+   bundle->meta_graph_def_ =
+       std::move(*saved_model_proto.mutable_meta_graphs(0));
+ 
++  // Correct the endiness of Tensor content on big-endian system
++  if (!port::kLittleEndian) {
++    TF_RETURN_IF_ERROR(ByteSwapTensorContent(&(bundle->meta_graph_def_)));
++  }
++
+   // Load GraphDebugInfo.
+   TF_RETURN_IF_ERROR(
+       ReadSavedModelDebugInfoIfPresent(export_dir, &bundle->debug_info_));
+diff --git a/tensorflow/cc/saved_model/reader.cc b/tensorflow/cc/saved_model/reader.cc
+index 16db9728c55..d39c0debe4d 100644
+--- a/tensorflow/cc/saved_model/reader.cc
++++ b/tensorflow/cc/saved_model/reader.cc
+@@ -72,35 +72,6 @@ Status ReadSavedModel(absl::string_view export_dir,
+                       export_dir));
+ }
+ 
+-// Swap tensor_content field of Const Op Tensors in the named functions
+-static Status SwapTensorContent(MetaGraphDef* meta_graph_def) {
+-  GraphDef graph_def = *meta_graph_def->mutable_graph_def();
+-  for (auto& function : *meta_graph_def->mutable_graph_def()
+-                             ->mutable_library()
+-                             ->mutable_function()) {
+-    for (auto& node : (*function.mutable_node_def())) {
+-      if (node.op() != "Const") continue;
+-      auto node_iterator = node.mutable_attr()->find("value");
+-      if (node_iterator == node.mutable_attr()->end()) continue;
+-      AttrValue node_value = node_iterator->second;
+-      if (!node_value.has_tensor()) continue;
+-
+-      auto tsize = node_value.mutable_tensor()->tensor_content().size();
+-      auto p_type = node_value.mutable_tensor()->dtype();
+-      // Swap only when there is something in tensor_content field
+-      if (tsize != 0 && DataTypeCanUseMemcpy(p_type)) {
+-        Tensor parsed(p_type);
+-        DCHECK(parsed.FromProto(*node_value.mutable_tensor()));
+-        TF_RETURN_IF_ERROR(ByteSwapTensor(&parsed));
+-        (*node.mutable_attr())["value"].mutable_tensor()->set_tensor_content(
+-            string(reinterpret_cast<const char*>(parsed.tensor_data().data()),
+-                   parsed.tensor_data().size()));
+-      }
+-    }
+-  }
+-  return Status::OK();
+-}
+-
+ Status FindMetaGraphDef(const std::unordered_set<string>& tags,
+                         SavedModel* saved_model_proto,
+                         MetaGraphDef* meta_graph_def) {
+@@ -117,7 +88,7 @@ Status FindMetaGraphDef(const std::unordered_set<string>& tags,
+       *meta_graph_def = std::move(graph_def);
+       // Correct the endiness of Tensor content on big-endian system
+       if (!port::kLittleEndian) {
+-        TF_RETURN_IF_ERROR(SwapTensorContent(meta_graph_def));
++        TF_RETURN_IF_ERROR(ByteSwapTensorContent(meta_graph_def));
+       }
+       return Status::OK();
+     }
+diff --git a/tensorflow/core/util/tensor_bundle/byte_swap.cc b/tensorflow/core/util/tensor_bundle/byte_swap.cc
+index 89a808ab2cf..631aceac104 100644
+--- a/tensorflow/core/util/tensor_bundle/byte_swap.cc
++++ b/tensorflow/core/util/tensor_bundle/byte_swap.cc
+@@ -15,43 +15,34 @@ limitations under the License.
+ 
+ #include "tensorflow/core/util/tensor_bundle/byte_swap.h"
+ 
++#include "tensorflow/core/framework/attr_value.pb.h"
++#include "tensorflow/core/framework/function.pb.h"
++#include "tensorflow/core/framework/graph.pb.h"
++#include "tensorflow/core/framework/node_def.pb.h"
++#include "tensorflow/core/framework/tensor.pb.h"
+ #include "tensorflow/core/lib/core/status.h"
+ 
+ namespace tensorflow {
+ 
+-Status ByteSwapArray(char* array, size_t bytes_per_elem, int array_len) {
+-  if (bytes_per_elem == 1) {
+-    // No-op
+-    return Status::OK();
+-  } else if (bytes_per_elem == 2) {
+-    auto array_16 = reinterpret_cast<uint16_t*>(array);
+-    for (int i = 0; i < array_len; i++) {
+-      array_16[i] = BYTE_SWAP_16(array_16[i]);
+-    }
+-    return Status::OK();
+-  } else if (bytes_per_elem == 4) {
+-    auto array_32 = reinterpret_cast<uint32_t*>(array);
+-    for (int i = 0; i < array_len; i++) {
+-      array_32[i] = BYTE_SWAP_32(array_32[i]);
+-    }
+-    return Status::OK();
+-  } else if (bytes_per_elem == 8) {
+-    auto array_64 = reinterpret_cast<uint64_t*>(array);
+-    for (int i = 0; i < array_len; i++) {
+-      array_64[i] = BYTE_SWAP_64(array_64[i]);
+-    }
+-    return Status::OK();
+-  } else {
+-    return errors::Unimplemented("Byte-swapping of ", bytes_per_elem,
+-                                 "-byte values not supported.");
+-  }
+-}
+-
+-Status ByteSwapTensor(Tensor* t) {
++namespace {
++
++// Byte-swap a buffer in place.
++//
++// Args:
++//  buff: pointer to the buffer to be modified IN PLACE.
++//  size: size of bytes in this buffer.
++//  dtype: type of data in this buffer.
++//  num_of_elem: number of data in this buffer, set to -1 if it
++//               could not be obtained directly from tensor data.
++//               If num_of_elem is -1, this function will calculate
++//               the number of data based on size and dtype.
++// Returns: Status::OK() on success, -1 otherwise
++Status ByteSwapBuffer(char* buff, size_t size, DataType dtype,
++                      int num_of_elem) {
++  int array_len = num_of_elem;
+   size_t bytes_per_elem = 0;
+-  int array_len = t->NumElements();
+ 
+-  switch (t->dtype()) {
++  switch (dtype) {
+     // Types that don't need byte-swapping
+     case DT_STRING:
+     case DT_QINT8:
+@@ -69,6 +60,7 @@ Status ByteSwapTensor(Tensor* t) {
+     case DT_UINT16:
+     case DT_INT16:
+       bytes_per_elem = 2;
++      array_len = (array_len == -1) ? size / bytes_per_elem : array_len;
+       break;
+ 
+     // 32-bit types
+@@ -77,6 +69,7 @@ Status ByteSwapTensor(Tensor* t) {
+     case DT_QINT32:
+     case DT_UINT32:
+       bytes_per_elem = 4;
++      array_len = (array_len == -1) ? size / bytes_per_elem : array_len;
+       break;
+ 
+     // 64-bit types
+@@ -84,16 +77,19 @@ Status ByteSwapTensor(Tensor* t) {
+     case DT_DOUBLE:
+     case DT_UINT64:
+       bytes_per_elem = 8;
++      array_len = (array_len == -1) ? size / bytes_per_elem : array_len;
+       break;
+ 
+     // Complex types need special handling
+     case DT_COMPLEX64:
+       bytes_per_elem = 4;
++      array_len = (array_len == -1) ? size / bytes_per_elem : array_len;
+       array_len *= 2;
+       break;
+ 
+     case DT_COMPLEX128:
+       bytes_per_elem = 8;
++      array_len = (array_len == -1) ? size / bytes_per_elem : array_len;
+       array_len *= 2;
+       break;
+ 
+@@ -101,17 +97,98 @@ Status ByteSwapTensor(Tensor* t) {
+     case DT_RESOURCE:
+     case DT_VARIANT:
+       return errors::Unimplemented(
+-          "Byte-swapping not yet implemented for tensors with dtype ",
+-          t->dtype());
++          "Byte-swapping not yet implemented for tensors with dtype ", dtype);
+ 
+     // Byte-swapping shouldn't make sense for other dtypes.
+     default:
+       return errors::Unimplemented(
+-          "Byte-swapping not supported for tensors with dtype ", t->dtype());
++          "Byte-swapping not supported for tensors with dtype ", dtype);
++  }
++
++  TF_RETURN_IF_ERROR(ByteSwapArray(buff, bytes_per_elem, array_len));
++  return Status::OK();
++}
++
++}  // namespace
++
++Status ByteSwapArray(char* array, size_t bytes_per_elem, int array_len) {
++  if (bytes_per_elem == 1) {
++    // No-op
++    return Status::OK();
++  } else if (bytes_per_elem == 2) {
++    auto array_16 = reinterpret_cast<uint16_t*>(array);
++    for (int i = 0; i < array_len; i++) {
++      array_16[i] = BYTE_SWAP_16(array_16[i]);
++    }
++    return Status::OK();
++  } else if (bytes_per_elem == 4) {
++    auto array_32 = reinterpret_cast<uint32_t*>(array);
++    for (int i = 0; i < array_len; i++) {
++      array_32[i] = BYTE_SWAP_32(array_32[i]);
++    }
++    return Status::OK();
++  } else if (bytes_per_elem == 8) {
++    auto array_64 = reinterpret_cast<uint64_t*>(array);
++    for (int i = 0; i < array_len; i++) {
++      array_64[i] = BYTE_SWAP_64(array_64[i]);
++    }
++    return Status::OK();
++  } else {
++    return errors::Unimplemented("Byte-swapping of ", bytes_per_elem,
++                                 "-byte values not supported.");
+   }
++}
++
++Status ByteSwapTensor(Tensor* t) {
++  char* buff = const_cast<char*>((t->tensor_data().data()));
++  return ByteSwapBuffer(buff, t->tensor_data().size(), t->dtype(),
++                        t->NumElements());
++}
+ 
+-  char* backing_buffer = const_cast<char*>((t->tensor_data().data()));
+-  TF_RETURN_IF_ERROR(ByteSwapArray(backing_buffer, bytes_per_elem, array_len));
++Status ByteSwapTensorContent(MetaGraphDef* meta_graph_def) {
++  for (auto& function : *meta_graph_def->mutable_graph_def()
++                             ->mutable_library()
++                             ->mutable_function()) {
++    for (auto& node : (*function.mutable_node_def())) {
++      if (node.op() == "Const") {
++        auto node_iterator = node.mutable_attr()->find("value");
++        if (node_iterator != node.mutable_attr()->end()) {
++          AttrValue node_value = node_iterator->second;
++          if (node_value.has_tensor()) {
++            auto tsize = node_value.mutable_tensor()->tensor_content().size();
++            auto p_type = node_value.mutable_tensor()->dtype();
++            // Swap only when there is something in tensor_content field
++            if (tsize != 0 && DataTypeCanUseMemcpy(p_type)) {
++              Tensor parsed(p_type);
++              DCHECK(parsed.FromProto(*node_value.mutable_tensor()));
++              if (!parsed.tensor_data().empty()) {
++                TF_RETURN_IF_ERROR(ByteSwapTensor(&parsed));
++                (*node.mutable_attr())["value"]
++                    .mutable_tensor()
++                    ->set_tensor_content(
++                        string(reinterpret_cast<const char*>(
++                                   parsed.tensor_data().data()),
++                               parsed.tensor_data().size()));
++              } else {
++                void* copy = tensorflow::port::Malloc(tsize);
++                memcpy(copy,
++                       string(node_value.mutable_tensor()->tensor_content())
++                           .data(),
++                       tsize);
++                TF_RETURN_IF_ERROR(
++                    ByteSwapBuffer((char*)copy, tsize, p_type, -1));
++                (*node.mutable_attr())["value"]
++                    .mutable_tensor()
++                    ->set_tensor_content(
++                        string(reinterpret_cast<const char*>(copy), tsize));
++                tensorflow::port::Free(copy);
++              }
++            }
++          }
++        }
++      }
++    }
++  }
+   return Status::OK();
+ }
+ 
+diff --git a/tensorflow/core/util/tensor_bundle/byte_swap.h b/tensorflow/core/util/tensor_bundle/byte_swap.h
+index ea59e644ec0..a51153385f8 100644
+--- a/tensorflow/core/util/tensor_bundle/byte_swap.h
++++ b/tensorflow/core/util/tensor_bundle/byte_swap.h
+@@ -19,6 +19,7 @@ limitations under the License.
+ #include "tensorflow/core/framework/tensor.h"
+ #include "tensorflow/core/lib/core/status.h"
+ #include "tensorflow/core/platform/byte_order.h"
++#include "tensorflow/core/protobuf/meta_graph.pb.h"
+ 
+ // Define basic byte swapping operations.
+ // These operations must be macros to use compiler intrinsics.
+@@ -108,6 +109,9 @@ Status ByteSwapArray(char *array, size_t bytes_per_elem, int array_len);
+ // TODO(frreiss): Should this be a member of the Tensor class?
+ Status ByteSwapTensor(Tensor *t);
+ 
++// Swap tensor_content field of Const Op Tensors in the named functions
++Status ByteSwapTensorContent(MetaGraphDef *meta_graph_def);
++
+ }  // namespace tensorflow
+ 
+ #endif  // TENSORFLOW_CORE_UTIL_TENSOR_BUNDLE_BYTE_SWAP_H_
+diff --git a/tensorflow/python/saved_model/loader_impl.py b/tensorflow/python/saved_model/loader_impl.py
+index 4381c8d4864..bb10d4c8807 100644
+--- a/tensorflow/python/saved_model/loader_impl.py
++++ b/tensorflow/python/saved_model/loader_impl.py
+@@ -20,6 +20,7 @@ from __future__ import division
+ from __future__ import print_function
+ 
+ import os
++import sys
+ 
+ from google.protobuf import message
+ from google.protobuf import text_format
+@@ -424,6 +425,9 @@ class SavedModelLoader(object):
+           `tf.import_graph_def` (may be `None`).
+     """
+     meta_graph_def = self.get_meta_graph_def_from_tags(tags)
++    if sys.byteorder == "big":
++      saved_model_utils.swap_function_tensor_content(meta_graph_def, "little",
++                                                     "big")
+     with graph.as_default():
+       return tf_saver._import_meta_graph_with_return_elements(  # pylint: disable=protected-access
+           meta_graph_def, import_scope=import_scope, **saver_kwargs)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,9 +39,10 @@ source:
     - 0311-Build-llvm-for-s390x-target.patch             #[s390x]
     - 0312-EIGEN-grpc-fix-s390x-target.patch             #[s390x]
     - 0313-hwloc-fix-s390x.patch                         #[s390x]
+    - 0314-Fix-Tensor-content-swap-s390x.patch           #[s390x]
 
 build:
-  number: 4
+  number: 5
   entry_points:
     - toco_from_protos = tensorflow.lite.toco.python.toco_from_protos:main
     - tflite_convert = tensorflow.lite.python.tflite_convert:main


### PR DESCRIPTION


## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes # (issue).
- Back port `https://github.com/tensorflow/tensorflow/pull/50152`
  into tensorflow 2.7.1.
- **Note**: PR `https://github.com/tensorflow/tensorflow/pull/45339` is
  already present in tensorflow 2.7.1

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
