### PR TITLE
Removed extra call to bazel shutdown

### DIFF
--- a/recipe/build-pip-package.sh
+++ b/recipe/build-pip-package.sh
@@ -51,10 +51,6 @@ $SCRIPT_DIR/set_tensorflow_bazelrc.sh $SRC_DIR/tensorflow
 
 #export BAZEL_LINKLIBS=-l%:libstdc++.a
 
-#Clean up old bazel cache to avoid problems building TF
-bazel clean --expunge
-bazel shutdown
-
 # On x86, use of new compilers (gcc8) gives "ModuleNotFoundError: No module named '_sysconfigdata_x86_64_conda_linux_gnu'"# This is due to the target triple difference with which python and conda-build are built. Below is the work around to this problem.
 # Conda-forge's python-feedstock has a patch https://github.com/conda-forge/python-feedstock/blob/master/recipe/patches/0010-Add-support-for-_CONDA_PYTHON_SYSCONFIGDATA_NAME-if-.patch which may address this problem.
 


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Removed this call as it is not needed or rather it doesn't do anything in actual. This call was initially added to kill bazel process from previous builds. But as per the bazel's documentation, bazel shutdown works in the same workspace where the bazel build is done. So, this call was neither harmful nor effective. Hence removed it.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
