### PR TITLE
Reduce resources to be used

### DIFF
--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -5,8 +5,7 @@ recipes:
   - name : tensorflow-base
     path : recipe
     resources:
-       memory: 200Gi  #[ppc64le]
-       memory: 10Gi   #[not ppc64le]
+       memory: 10Gi
 
   - name : tensorflow-meta
     path : meta_recipe

--- a/recipe/build-pip-package.sh
+++ b/recipe/build-pip-package.sh
@@ -63,7 +63,7 @@ fi
 bazel --bazelrc=$SRC_DIR/tensorflow/tensorflow.bazelrc build \
     --local_cpu_resources=HOST_CPUS*0.50 \
     --local_ram_resources=HOST_RAM*0.50 \
-    --jobs=HOST_CPUS*0.5 \
+    --jobs=32 \
     --config=opt \
     --config=numa \
     --curses=no \


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Reducing number of jobs to be used by bazel build to 32 and also reducing the RAM requested by TF build to OCP cluster. These changes are specifically done so that TF builds on low resource OCP cluster.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
